### PR TITLE
Configurable registries

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,14 +11,17 @@ jobs:
 
     name: Build and test
     runs-on: ubuntu-latest
-
+    strategy:
+        matrix:
+          otp: ['21.3.8', '22.3.4', '23.3.4']
+          elixir: ['1.9.4', '1.10.4']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.10.3' # Define the elixir version [required]
-        otp-version: '22.3' # Define the OTP version [required]
+        otp-version: ${{matrix.otp}}
+        elixir-version: ${{matrix.elixir}}
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 ccs811-*.tar
 
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -52,7 +52,23 @@ Add to your application initialization
 Which will set the driver to periodically execute a telemetry event named `[:ccs811, :read]` 
 with a new data map containing values for eCO2 `:eco2` and TVOC `tvoc`
 
+## Initialization
+
+both `Ccs811.start_polling()` and `Ccs811.initialize()` supports additional configuration parameters that can be passed as a keyword list
+
+|Key|description|default
+|---|---|-----|
+|`:slave_address`|the sensor slave address|0x5A
+|`:period`|the polling period in seconds|30
+
+Example:
+
+```elixir
+Ccs811.start_polling(period: 60)
+```
+
+
 ### Missing features:
 - Configuring humidity and temperature
 - Interrupt based data reading instead of polling
-- Configuration for Bus-name and polling period (currently it uses the first available I2C bus)
+- Configuration for Bus-name (currently it uses the first available I2C bus)

--- a/lib/ccs811.ex
+++ b/lib/ccs811.ex
@@ -22,13 +22,17 @@ defmodule Ccs811 do
     end
   end)
 
-  def initialize() do
+  def initialize(args \\ []) do
+    :ok = Registries.init(args)
     app_start()
     set_meas_mode(:mode_1)
+
+    :ok
   end
 
-  def start_polling() do
-    Ccs811.Telemetry.start_polling()
+  @spec start_polling(keyword) :: :ignore | {:error, any} | {:ok, pid} | {:ok, pid, any}
+  def start_polling(args \\ []) do
+    Ccs811.Telemetry.start_polling(args)
   end
 
   def app_verify(), do: write_registry(Registries.verify())
@@ -134,6 +138,7 @@ defmodule Ccs811 do
   end
 
   defp get_i2c_bus_name do
+    # TOD: check for application config
     case Circuits.I2C.bus_names() do
       [] -> {:error, :no_bus_names}
       [first_available_bus_name | _] -> {:ok, first_available_bus_name}

--- a/lib/ccs811/registries.ex
+++ b/lib/ccs811/registries.ex
@@ -8,7 +8,7 @@ defmodule Ccs811.Registries do
   @slave_address_key :slave_address
 
   def init(opts \\ []) do
-    :ets.new(@table_name, [:set, :private, :named_table])
+    :ets.new(@table_name, [:set, :protected, :named_table])
 
     slave_address = Keyword.get(opts, :slave_address, @default_slave_address)
     :ets.insert(@table_name, {@slave_address_key, slave_address})
@@ -42,6 +42,6 @@ defmodule Ccs811.Registries do
     [{@slave_address_key, slave_address}] = :ets.lookup(@table_name, :slave_address)
     slave_address
   rescue
-    _ -> raise "#{__MODULE__} not initialized, use #{__MODULE__}.init before trying to use it"
+    _ -> raise "#{__MODULE__} not initialized, use #{__MODULE__}.init before using it"
   end
 end

--- a/lib/ccs811/registries.ex
+++ b/lib/ccs811/registries.ex
@@ -1,4 +1,21 @@
 defmodule Ccs811.Registries do
+  @moduledoc """
+  Represents the registries configuration, needs to be initialized
+  """
+
+  @table_name :registries_config
+  @default_slave_address 0x5A
+  @slave_address_key :slave_address
+
+  def init(opts \\ []) do
+    :ets.new(@table_name, [:set, :private, :named_table])
+
+    slave_address = Keyword.get(opts, :slave_address, @default_slave_address)
+    :ets.insert(@table_name, {@slave_address_key, slave_address})
+
+    :ok
+  end
+
   def all() do
     %{
       status: %{address: 0x00, bytes: 1, read: true, write: false},
@@ -21,5 +38,10 @@ defmodule Ccs811.Registries do
   def verify(), do: 0xF3
   def start(), do: 0xF4
 
-  def slave_address(), do: 0x5A
+  def slave_address() do
+    [{@slave_address_key, slave_address}] = :ets.lookup(@table_name, :slave_address)
+    slave_address
+  rescue
+    _ -> raise "#{__MODULE__} not initialized, use #{__MODULE__}.init before trying to use it"
+  end
 end

--- a/test/registries_test.exs
+++ b/test/registries_test.exs
@@ -1,0 +1,22 @@
+defmodule Ccs811.RegistriesTest do
+  use ExUnit.Case
+  doctest Ccs811.Registries
+
+  alias Ccs811.Registries
+
+  describe "slave_address/0" do
+    test "returns 0x5A by default" do
+      :ok = Registries.init()
+      assert Registries.slave_address() == 0x5A
+    end
+
+    test "returns new value when overridden" do
+      :ok = Registries.init(slave_address: 0x5B)
+      assert Registries.slave_address() == 0x5B
+    end
+
+    test "returns error when registries is not initialized" do
+      assert_raise(RuntimeError, fn -> Registries.slave_address() end)
+    end
+  end
+end


### PR DESCRIPTION
As reported in https://github.com/Efesto/ccs811/issues/1, this PR allows to configure the `:slave_address` and the `:polling_period`

@jfburdet please have a look and test it out if it works for you

You can refer to the updated Readme for the address configuration